### PR TITLE
Bump to next alpha version after creating release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Added
+- Bump to next alpha version after creating release
+
 ## v0.0.3 (2021-01-26)
 - Ensure in PR CI runs that the current version contains "alpha" & that there's no git diff (e.g.
   due to failing to run `bundle` after updating the version)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GIT
 PATH
   remote: .
   specs:
-    release_assistant (0.0.3)
+    release_assistant (0.0.4.alpha)
       activesupport (~> 6.0)
       colorize (~> 0.8)
       memoist (~> 0.16)

--- a/lib/release_assistant/version.rb
+++ b/lib/release_assistant/version.rb
@@ -2,6 +2,6 @@
 
 # rubocop:disable Style/StaticClass
 class ReleaseAssistant
-  VERSION = '0.0.3'
+  VERSION = '0.0.4.alpha'
 end
 # rubocop:enable Style/StaticClass


### PR DESCRIPTION
This sets the stage for future changes to be made without requiring the first such change being made to also bump to an alpha version. (This is particularly valuable since, for example, dependabot doesn't know that it should bump the version to the next alpha version when making changes.)