### PR TITLE
Rename with "Runger" prefix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,6 +18,6 @@ jobs:
     - name: Run RSpec tests
       run: bin/rspec --format progress
     - name: Ensure alpha version
-      run: grep alpha lib/release_assistant/version.rb
+      run: grep alpha lib/runger_release_assistant/version.rb
     - name: Ensure no git diff
       run: git diff --exit-code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
-[no unreleased changes yet]
+### Changed
+- Rename with "Runger" prefix
+  - For backwards compatibility, the (optional) config file will still be called
+    `.release_assistant.yml` (not `.runger_release_assistant.yml`)
 
 ## v0.3.2 (2021-02-05)
 ### Changed
@@ -10,7 +13,7 @@
 - Release the correct (non-alpha) gem verision to RubyGems
 
 ### Changed
-- Validate when initializing `ReleaseAssistant` that options are valid (which currently entails only
+- Validate when initializing `RungerReleaseAssistant` that options are valid (which currently entails only
   checking for `git: true`)
 - Always show system output for the release phase when pushing to RubyGems (if pushing to RubyGems)
   in order to allow for engaging with the RubyGems 2FA prompt (which should be enabled)
@@ -40,7 +43,7 @@
 
 ## v0.0.1 (2021-01-26)
 ### Added
-- Create `release_assistant` tool to aid with releasing/publishing gems (particularly via GitHub)
+- Create `runger_release_assistant` tool to aid with releasing/publishing gems (particularly via GitHub)
 - Require confirmation before releasing
 - Restore original state (current git branch, file contents) when aborting
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-# Specify your gem's dependencies in release_assistant.gemspec
+# Specify your gem's dependencies in runger_release_assistant.gemspec
 gemspec
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    release_assistant (0.3.3.alpha)
+    runger_release_assistant (0.3.3.alpha)
       activesupport (>= 6, < 8)
       colorize (~> 0.8)
       memoist (~> 0.16)
@@ -21,7 +21,7 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
-    i18n (1.12.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     memoist (0.16.2)
@@ -92,11 +92,11 @@ DEPENDENCIES
   pry
   pry-byebug
   rake
-  release_assistant!
   rspec
   rubocop
   rubocop-performance
   rubocop-rspec
+  runger_release_assistant!
   runger_style
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-![GitHub tag (latest SemVer pre-release)](https://img.shields.io/github/v/tag/davidrunger/release_assistant?include_prereleases)
+![GitHub tag (latest SemVer pre-release)](https://img.shields.io/github/v/tag/davidrunger/runger_release_assistant?include_prereleases)
 
-# `release_assistant`
+# `runger_release_assistant`
 
 This is a CLI tool that helps to automate the process of releasing new versions of a gem via
 git/GitHub and (optionally) via RubyGems.
 
 <!--ts-->
-   * [release_assistant](#release_assistant)
+   * [runger_release_assistant](#runger_release_assistant)
       * [Dependencies](#dependencies)
       * [Installation](#installation)
          * [Global installation](#global-installation)
@@ -31,24 +31,24 @@ This gem assumes that you have `git` installed.
 
 ### Global installation
 
-The easiest way to install `release_assistant` "globally" on your machine is via the
+The easiest way to install `runger_release_assistant` "globally" on your machine is via the
 [`specific_install`](https://github.com/rdp/specific_install) gem, which will pull and build the
-`release_assistant` gem directly from the `master` branch of this repo:
+`runger_release_assistant` gem directly from the `master` branch of this repo:
 
 ```
 gem install specific_install
-gem specific_install davidrunger/release_assistant
+gem specific_install davidrunger/runger_release_assistant
 ```
 
 Then you can execute `release` anywhere on your machine.
 
 ### Installation in a specific project
 
-Add `release_assistant` to your `Gemfile`:
+Add `runger_release_assistant` to your `Gemfile`:
 
 ```rb
 group :development do
-  gem 'release_assistant', require: false, git: 'https://github.com/davidrunger/release_assistant'
+  gem 'runger_release_assistant', require: false, git: 'https://github.com/davidrunger/runger_release_assistant'
 end
 ```
 
@@ -59,7 +59,7 @@ Then, you can execute `bundle exec release`.
 When using bundler, you can create a binstub via:
 
 ```
-bundle binstubs release_assistant
+bundle binstubs runger_release_assistant
 ```
 
 Then, you can execute `bin/release`.
@@ -121,7 +121,7 @@ primary_branch: main
 
 ## Using with RubyGems
 
-By default, `release_assistant` assumes that you only want to "release" your gem via GitHub. If
+By default, `runger_release_assistant` assumes that you only want to "release" your gem via GitHub. If
 you'd also like to release the gem via RubyGems, then create a `.release_assistant.yml` file by
 executing `release --init`. Within that file, modify the default `rubygems: false` option to
 `rubygems: true`.
@@ -137,7 +137,7 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at
-https://github.com/davidrunger/release_assistant.
+https://github.com/davidrunger/runger_release_assistant.
 
 ## License
 

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'release_assistant'
+require 'runger_release_assistant'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/exe/release
+++ b/exe/release
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 require 'slop'
-require_relative '../lib/release_assistant.rb'
+require_relative '../lib/runger_release_assistant.rb'
 
 slop_options =
   Slop.parse do |o|
@@ -17,19 +17,19 @@ slop_options =
         release -t patch
     BANNER
 
-    ReleaseAssistant.define_slop_options(o)
+    RungerReleaseAssistant.define_slop_options(o)
 
     o.on('-i', '--init', 'create a `.release_assistant.yml` config file') do
       File.write(
         '.release_assistant.yml',
-        YAML.dump(ReleaseAssistant::DEFAULT_OPTIONS.stringify_keys),
+        YAML.dump(RungerReleaseAssistant::DEFAULT_OPTIONS.stringify_keys),
       )
       puts("Created #{'.release_assistant.yml'.green.bold}!")
       exit
     end
 
     o.on('-v', '--version', 'print the version') do
-      puts(ReleaseAssistant::VERSION)
+      puts(RungerReleaseAssistant::VERSION)
       exit
     end
 
@@ -39,10 +39,10 @@ slop_options =
     end
   end
 
-config_file_options = ReleaseAssistant::ConfigFileReader.new.options_hash
+config_file_options = RungerReleaseAssistant::ConfigFileReader.new.options_hash
 
-ReleaseAssistant.new(
-  ReleaseAssistant::DEFAULT_OPTIONS.
+RungerReleaseAssistant.new(
+  RungerReleaseAssistant::DEFAULT_OPTIONS.
     merge(config_file_options).
     merge(slop_options.to_h),
 ).run_release

--- a/lib/runger_release_assistant.rb
+++ b/lib/runger_release_assistant.rb
@@ -6,16 +6,15 @@ require 'memoist'
 require 'slop'
 require 'yaml'
 
-# This `ReleaseAssistant` class is the namespace within which most of the gem's code is written.
 # We need to define the class before requiring the modules.
 # rubocop:disable Lint/EmptyClass
-class ReleaseAssistant
+class RungerReleaseAssistant
 end
 # rubocop:enable Lint/EmptyClass
 
-Dir["#{File.dirname(__FILE__)}/release_assistant/**/*.rb"].each { |file| require file }
+Dir["#{File.dirname(__FILE__)}/runger_release_assistant/**/*.rb"].each { |file| require file }
 
-class ReleaseAssistant
+class RungerReleaseAssistant
   extend Memoist
 
   DEFAULT_OPTIONS = { git: true, rubygems: false }.freeze
@@ -37,7 +36,10 @@ class ReleaseAssistant
   memoize \
   def logger
     Logger.new($stdout).tap do |logger|
-      logger.formatter = ->(_severity, _datetime, _progname, msg) { "[release_assistant] #{msg}\n" }
+      logger.formatter =
+        ->(_severity, _datetime, _progname, msg) {
+          "[runger_release_assistant] #{msg}\n"
+        }
       logger.level = @options[:debug] ? Logger::DEBUG : Logger::INFO
     end
   end
@@ -241,12 +243,14 @@ class ReleaseAssistant
 
   def alpha_version_after_next_version
     next_patch_version =
-      ReleaseAssistant::VersionCalculator.new(current_version: next_version).increment_for('patch')
+      RungerReleaseAssistant::VersionCalculator.new(
+        current_version: next_version,
+      ).increment_for('patch')
     "#{next_patch_version}.alpha"
   end
 
   memoize \
   def version_calculator
-    ReleaseAssistant::VersionCalculator.new(current_version:)
+    RungerReleaseAssistant::VersionCalculator.new(current_version:)
   end
 end

--- a/lib/runger_release_assistant/config_file_reader.rb
+++ b/lib/runger_release_assistant/config_file_reader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ReleaseAssistant::ConfigFileReader
+class RungerReleaseAssistant::ConfigFileReader
   extend Memoist
 
   memoize \

--- a/lib/runger_release_assistant/version.rb
+++ b/lib/runger_release_assistant/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Style/StaticClass
-class ReleaseAssistant
+class RungerReleaseAssistant
   VERSION = '0.3.3.alpha'
 end
 # rubocop:enable Style/StaticClass

--- a/lib/runger_release_assistant/version_calculator.rb
+++ b/lib/runger_release_assistant/version_calculator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ReleaseAssistant::VersionCalculator
+class RungerReleaseAssistant::VersionCalculator
   extend Memoist
 
   def initialize(current_version:)

--- a/runger_release_assistant.gemspec
+++ b/runger_release_assistant.gemspec
@@ -2,16 +2,16 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'release_assistant/version'
+require 'runger_release_assistant/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'release_assistant'
-  spec.version       = ReleaseAssistant::VERSION
+  spec.name          = 'runger_release_assistant'
+  spec.version       = RungerReleaseAssistant::VERSION
   spec.authors       = ['David Runger']
   spec.email         = ['davidjrunger@gmail.com']
 
   spec.summary       = 'CLI tool for parsing git history'
-  spec.homepage      = 'https://github.com/davidrunger/release_assistant'
+  spec.homepage      = 'https://github.com/davidrunger/runger_release_assistant'
   spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
     spec.metadata['allowed_push_host'] = 'https://davidrunger.com'
 
     spec.metadata['homepage_uri'] = spec.homepage
-    spec.metadata['source_code_uri'] = 'https://github.com/davidrunger/release_assistant'
+    spec.metadata['source_code_uri'] = 'https://github.com/davidrunger/runger_release_assistant'
     spec.metadata['changelog_uri'] =
-      'https://github.com/davidrunger/release_assistant/blob/master/CHANGELOG.md'
+      'https://github.com/davidrunger/runger_release_assistant/blob/master/CHANGELOG.md'
   else
     raise('RubyGems 2.0 or newer is required to protect against public gem pushes.')
   end

--- a/spec/release_assistant/version_spec.rb
+++ b/spec/release_assistant/version_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe 'ReleaseAssistant::VERSION' do
-  it 'is not nil' do
-    expect(ReleaseAssistant::VERSION).not_to eq(nil)
-  end
-end

--- a/spec/runger_release_assistant/version_spec.rb
+++ b/spec/runger_release_assistant/version_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe 'RungerReleaseAssistant::VERSION' do
+  it 'is not nil' do
+    expect(RungerReleaseAssistant::VERSION).not_to eq(nil)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'bundler/setup'
 Bundler.require(:test)
-require_relative '../lib/release_assistant.rb'
+require_relative '../lib/runger_release_assistant.rb'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
This is in preparation for releasing via RubyGems, but I don't want to claim the gem name `release_assistant`.